### PR TITLE
Fix Cursor configuration documentation

### DIFF
--- a/MCP_SERVER_README.md
+++ b/MCP_SERVER_README.md
@@ -58,21 +58,18 @@ Add the claude-search server to your configuration:
   "mcpServers": {
     // ... other servers ...
     "claude-search": {
-      "command": "/path/to/semantic-search/.venv/bin/python",
-      "args": ["-m", "src.mcp_server"],
-      "cwd": "/path/to/semantic-search",
-      "env": {
-        "PYTHONPATH": "/path/to/semantic-search"
-      }
+      "command": "/Users/USERNAME/.local/bin/uv",
+      "args": ["run", "--directory", "/path/to/semantic-search", "claude-search-mcp"],
+      "cwd": "/path/to/semantic-search"
     }
   }
 }
 ```
 
 **Important**: 
-- Replace `/path/to/semantic-search` with your actual path
+- Replace `/Users/USERNAME/.local/bin/uv` with your actual UV path (find it with `which uv`)
+- Replace `/path/to/semantic-search` with your actual project path
 - Ensure the JSON is properly formatted (no line breaks in strings)
-- The `PYTHONPATH` environment variable is required for module imports
 
 ### 4. Restart Claude Desktop or Cursor
 

--- a/README.md
+++ b/README.md
@@ -373,6 +373,7 @@ Add to `~/.cursor/mcp.json`:
   }
 }
 ```
+**Note**: Replace `/Users/USERNAME/.local/bin/uv` with your actual UV path (find it with `which uv`)
 
 ### Available MCP Tools
 


### PR DESCRIPTION
## Summary
- Fixed incorrect Cursor configuration that showed venv/python method which doesn't work
- Updated to show the correct UV path configuration that actually works
- Added clear instructions to find UV path with `which uv`

## Changes
- Updated MCP_SERVER_README.md section 3 to show correct UV configuration
- Updated README.md Cursor IDE section to match
- Removed non-working venv/python configuration

## Context
The previous documentation showed a configuration that results in "0 tools enabled" error in Cursor. The updated configuration using full UV path is what actually works.