### PR TITLE
Improve README image layout consistency

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,14 @@
 
 A powerful semantic search system for Claude conversations that enables fast, intelligent retrieval through natural language queries. Access your Claude Code sessions from anywhere - Claude Code itself, CLI, Claude Desktop, Cursor IDE, and Alfred (in development)!
 
-<div align="center">
+<figure style="text-align: center;">
   <img width="800" alt="Screenshot of the Claude Semantic Search interface showing search results for a query" src="https://github.com/user-attachments/assets/b5d35184-27b7-44c3-b4aa-9dc7c6e21af6" />
-  <br/><br/>
+  <figcaption>Screenshot of the Claude Semantic Search interface showing search results for a query</figcaption>
+</figure>
+<figure style="text-align: center;">
   <img width="800" alt="Screenshot of the settings page for configuring Claude Semantic Search" src="https://github.com/user-attachments/assets/fb9c87f1-0637-481f-82c9-45842a3a6b19" />
-</div>
+  <figcaption>Screenshot of the settings page for configuring Claude Semantic Search</figcaption>
+</figure>
 
 ## Why This Project?
 

--- a/README.md
+++ b/README.md
@@ -2,10 +2,11 @@
 
 A powerful semantic search system for Claude conversations that enables fast, intelligent retrieval through natural language queries. Access your Claude Code sessions from anywhere - Claude Code itself, CLI, Claude Desktop, Cursor IDE, and Alfred (in development)!
 
-<img width="2551" height="1471" alt="Screenshot of the Claude Semantic Search interface showing search results for a query" src="https://github.com/user-attachments/assets/b5d35184-27b7-44c3-b4aa-9dc7c6e21af6" />
-
-<img width="744" height="557" alt="Screenshot of the settings page for configuring Claude Semantic Search" src="https://github.com/user-attachments/assets/fb9c87f1-0637-481f-82c9-45842a3a6b19" />
-
+<div align="center">
+  <img width="800" alt="Screenshot of the Claude Semantic Search interface showing search results for a query" src="https://github.com/user-attachments/assets/b5d35184-27b7-44c3-b4aa-9dc7c6e21af6" />
+  <br/><br/>
+  <img width="800" alt="Screenshot of the settings page for configuring Claude Semantic Search" src="https://github.com/user-attachments/assets/fb9c87f1-0637-481f-82c9-45842a3a6b19" />
+</div>
 
 ## Why This Project?
 


### PR DESCRIPTION
## Summary
Updates the README screenshot layout for better visual consistency and professional appearance.

## Changes
- Set both images to same width (800px)
- Center images using `<div align="center">`
- Add proper spacing between images
- Remove height attributes to maintain aspect ratios

## Before
- First image: 2551px wide
- Second image: 744px wide
- Left-aligned
- Inconsistent sizing

## After
- Both images: 800px wide
- Center-aligned
- Consistent sizing
- Better visual flow

This creates a cleaner, more professional appearance for the README.