### PR TITLE
Fix daemon path expansion bug

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "claude-semantic-search"
-version = "0.1.0"
+version = "0.1.1"
 description = "Semantic search system for Claude conversations"
 authors = []
 requires-python = ">=3.11"

--- a/src/cli.py
+++ b/src/cli.py
@@ -288,7 +288,8 @@ class SemanticSearchCLI:
 def cli(ctx: click.Context, data_dir: str) -> None:
     """Claude Semantic Search CLI - Index and search your Claude conversations."""
     ctx.ensure_object(dict)
-    ctx.obj["data_dir"] = data_dir
+    # Expand user path to handle ~ properly
+    ctx.obj["data_dir"] = str(Path(data_dir).expanduser())
 
 
 @cli.command()

--- a/src/cli.py
+++ b/src/cli.py
@@ -281,13 +281,18 @@ class SemanticSearchCLI:
 @click.group()
 @click.option(
     "--data-dir",
-    default=lambda: os.environ.get("CLAUDE_SEARCH_DATA_DIR", "~/.claude-semantic-search/data"),
+    default=None,
     help="Data directory for storage (env: CLAUDE_SEARCH_DATA_DIR)"
 )
 @click.pass_context
 def cli(ctx: click.Context, data_dir: str) -> None:
     """Claude Semantic Search CLI - Index and search your Claude conversations."""
     ctx.ensure_object(dict)
+    
+    # Handle default data directory and expand user path
+    if data_dir is None:
+        data_dir = os.environ.get("CLAUDE_SEARCH_DATA_DIR", "~/.claude-semantic-search/data")
+    
     # Expand user path to handle ~ properly
     ctx.obj["data_dir"] = str(Path(data_dir).expanduser())
 

--- a/src/mcp_server.py
+++ b/src/mcp_server.py
@@ -135,6 +135,7 @@ def get_search_cli(use_gpu: bool = False) -> SemanticSearchCLI:
     if search_cli is None or search_cli.use_gpu != use_gpu:
         # Use environment variable or default data directory
         data_dir = os.environ.get("CLAUDE_SEARCH_DATA_DIR", "~/.claude-semantic-search/data")
+        data_dir = str(Path(data_dir).expanduser())  # Expand ~ to full path
         search_cli = SemanticSearchCLI(data_dir, use_gpu=use_gpu)
     return search_cli
 

--- a/src/watcher.py
+++ b/src/watcher.py
@@ -124,14 +124,16 @@ class ConversationWatcher:
     ):
         """Initialize watcher."""
         self.data_dir = data_dir or os.environ.get("CLAUDE_SEARCH_DATA_DIR", "~/.claude-semantic-search/data")
+        # Expand user path to handle ~ properly
+        self.data_dir = str(Path(self.data_dir).expanduser())
         self.debounce_seconds = debounce_seconds
         self.use_gpu = use_gpu
-        self.cli_instance = SemanticSearchCLI(data_dir, use_gpu)
+        self.cli_instance = SemanticSearchCLI(self.data_dir, use_gpu)
         self.observer = Observer()
         self.handler = ConversationFileHandler(self.cli_instance, debounce_seconds)
         self.is_running = False
-        self.pid_file = Path(data_dir) / "watcher.pid"
-        self.log_file = Path(data_dir) / "watcher.log"
+        self.pid_file = Path(self.data_dir) / "watcher.pid"
+        self.log_file = Path(self.data_dir) / "watcher.log"
 
     def start_watching(self, claude_dir: str = "~/.claude/projects"):
         """Start watching for file changes."""
@@ -323,6 +325,7 @@ def run_watcher(
 ):
     """Run the file watcher in interactive mode."""
     data_dir = data_dir or os.environ.get("CLAUDE_SEARCH_DATA_DIR", "~/.claude-semantic-search/data")
+    data_dir = str(Path(data_dir).expanduser())  # Expand ~ to full path
     watcher = ConversationWatcher(data_dir, debounce_seconds, use_gpu)
 
     try:
@@ -340,6 +343,7 @@ def start_daemon(
 ):
     """Start the file watcher as a daemon."""
     data_dir = data_dir or os.environ.get("CLAUDE_SEARCH_DATA_DIR", "~/.claude-semantic-search/data")
+    data_dir = str(Path(data_dir).expanduser())  # Expand ~ to full path
     watcher = ConversationWatcher(data_dir, debounce_seconds, use_gpu)
 
     # Fork process to run in background
@@ -367,6 +371,7 @@ def start_daemon(
 def stop_daemon(data_dir: str = None):
     """Stop the file watcher daemon."""
     data_dir = data_dir or os.environ.get("CLAUDE_SEARCH_DATA_DIR", "~/.claude-semantic-search/data")
+    data_dir = str(Path(data_dir).expanduser())  # Expand ~ to full path
     watcher = ConversationWatcher(data_dir)
 
     try:
@@ -383,6 +388,7 @@ def stop_daemon(data_dir: str = None):
 def daemon_status(data_dir: str = None):
     """Check daemon status."""
     data_dir = data_dir or os.environ.get("CLAUDE_SEARCH_DATA_DIR", "~/.claude-semantic-search/data")
+    data_dir = str(Path(data_dir).expanduser())  # Expand ~ to full path
     watcher = ConversationWatcher(data_dir)
 
     if watcher.is_daemon_running():

--- a/src/watcher.py
+++ b/src/watcher.py
@@ -123,9 +123,12 @@ class ConversationWatcher:
         self, data_dir: str = None, debounce_seconds: int = 5, use_gpu: bool = False
     ):
         """Initialize watcher."""
+        print(f"DEBUG INIT: input data_dir = {data_dir}")
         self.data_dir = data_dir or os.environ.get("CLAUDE_SEARCH_DATA_DIR", "~/.claude-semantic-search/data")
+        print(f"DEBUG INIT: after default = {self.data_dir}")
         # Expand user path to handle ~ properly
         self.data_dir = str(Path(self.data_dir).expanduser())
+        print(f"DEBUG INIT: after expand = {self.data_dir}")
         self.debounce_seconds = debounce_seconds
         self.use_gpu = use_gpu
         self.cli_instance = SemanticSearchCLI(self.data_dir, use_gpu)
@@ -134,6 +137,7 @@ class ConversationWatcher:
         self.is_running = False
         self.pid_file = Path(self.data_dir) / "watcher.pid"
         self.log_file = Path(self.data_dir) / "watcher.log"
+        print(f"DEBUG INIT: final paths - pid={self.pid_file}, log={self.log_file}")
 
     def start_watching(self, claude_dir: str = "~/.claude/projects"):
         """Start watching for file changes."""
@@ -200,6 +204,12 @@ class ConversationWatcher:
 
     def setup_daemon_logging(self):
         """Setup logging for daemon mode."""
+        # Debug: Print the actual paths
+        print(f"DEBUG: self.data_dir = {self.data_dir}")
+        print(f"DEBUG: self.log_file = {self.log_file}")
+        print(f"DEBUG: self.log_file.parent = {self.log_file.parent}")
+        # Ensure log directory exists
+        self.log_file.parent.mkdir(parents=True, exist_ok=True)
         # Create file handler for daemon logging
         file_handler = logging.FileHandler(self.log_file)
         file_handler.setLevel(logging.INFO)
@@ -221,6 +231,11 @@ class ConversationWatcher:
 
     def write_pid_file(self):
         """Write PID file."""
+        # Debug: Print the actual paths
+        print(f"DEBUG PID: self.data_dir = {self.data_dir}")
+        print(f"DEBUG PID: self.pid_file = {self.pid_file}")
+        # Ensure directory exists
+        self.pid_file.parent.mkdir(parents=True, exist_ok=True)
         with open(self.pid_file, "w") as f:
             f.write(str(os.getpid()))
         logger.info(f"PID file written: {self.pid_file}")
@@ -362,9 +377,14 @@ def start_daemon(
 
     # Child process or non-Unix system
     try:
+        print(f"DEBUG CHILD: About to call watcher.start_daemon with claude_dir={claude_dir}")
+        print(f"DEBUG CHILD: watcher.data_dir = {watcher.data_dir}")
+        print(f"DEBUG CHILD: watcher.log_file = {watcher.log_file}")
         watcher.start_daemon(claude_dir)
     except Exception as e:
         print(f"❌ Failed to start daemon: {str(e)}")
+        import traceback
+        traceback.print_exc()
         sys.exit(1)
 
 

--- a/src/watcher.py
+++ b/src/watcher.py
@@ -123,14 +123,9 @@ class ConversationWatcher:
         self, data_dir: str = None, debounce_seconds: int = 5, use_gpu: bool = False
     ):
         """Initialize watcher."""
-        original_data_dir = data_dir
         self.data_dir = data_dir or os.environ.get("CLAUDE_SEARCH_DATA_DIR", "~/.claude-semantic-search/data")
         # Always expand user path to handle ~ properly, even if already expanded
         self.data_dir = str(Path(self.data_dir).expanduser())
-        
-        print(f"WATCHER INIT DEBUG: original_data_dir = {original_data_dir}")
-        print(f"WATCHER INIT DEBUG: self.data_dir = {self.data_dir}")
-        print(f"WATCHER INIT DEBUG: CWD = {os.getcwd()}")
         
         self.debounce_seconds = debounce_seconds
         self.use_gpu = use_gpu
@@ -140,8 +135,6 @@ class ConversationWatcher:
         self.is_running = False
         self.pid_file = Path(self.data_dir) / "watcher.pid"
         self.log_file = Path(self.data_dir) / "watcher.log"
-        
-        print(f"WATCHER INIT DEBUG: self.log_file = {self.log_file}")
 
     def start_watching(self, claude_dir: str = "~/.claude/projects"):
         """Start watching for file changes."""
@@ -219,13 +212,10 @@ class ConversationWatcher:
 
     def setup_daemon_logging(self):
         """Setup logging for daemon mode."""
-        # Debug the exact path being used
-        print(f"DAEMON LOGGING DEBUG: self.log_file = {self.log_file}")
-        print(f"DAEMON LOGGING DEBUG: absolute = {self.log_file.resolve()}")
         # Ensure log directory exists
         self.log_file.parent.mkdir(parents=True, exist_ok=True)
         # Create file handler for daemon logging
-        file_handler = logging.FileHandler(self.log_file)
+        file_handler = logging.FileHandler(str(self.log_file))
         file_handler.setLevel(logging.INFO)
 
         # Create formatter
@@ -382,7 +372,7 @@ def start_daemon(
             print(f"✅ Watcher daemon started with PID: {pid}")
             print(f"📁 Watching: {claude_dir}")
             print(f"💾 Data directory: {data_dir}")
-            print(f"📝 Log file: {watcher.log_file}")
+            print(f"📝 Log file: {str(watcher.log_file)}")
             return
     except OSError:
         # Fork not supported (Windows), run directly

--- a/src/watcher.py
+++ b/src/watcher.py
@@ -123,9 +123,15 @@ class ConversationWatcher:
         self, data_dir: str = None, debounce_seconds: int = 5, use_gpu: bool = False
     ):
         """Initialize watcher."""
+        original_data_dir = data_dir
         self.data_dir = data_dir or os.environ.get("CLAUDE_SEARCH_DATA_DIR", "~/.claude-semantic-search/data")
-        # Expand user path to handle ~ properly
+        # Always expand user path to handle ~ properly, even if already expanded
         self.data_dir = str(Path(self.data_dir).expanduser())
+        
+        print(f"WATCHER INIT DEBUG: original_data_dir = {original_data_dir}")
+        print(f"WATCHER INIT DEBUG: self.data_dir = {self.data_dir}")
+        print(f"WATCHER INIT DEBUG: CWD = {os.getcwd()}")
+        
         self.debounce_seconds = debounce_seconds
         self.use_gpu = use_gpu
         self.cli_instance = SemanticSearchCLI(self.data_dir, use_gpu)
@@ -134,6 +140,8 @@ class ConversationWatcher:
         self.is_running = False
         self.pid_file = Path(self.data_dir) / "watcher.pid"
         self.log_file = Path(self.data_dir) / "watcher.log"
+        
+        print(f"WATCHER INIT DEBUG: self.log_file = {self.log_file}")
 
     def start_watching(self, claude_dir: str = "~/.claude/projects"):
         """Start watching for file changes."""
@@ -211,6 +219,9 @@ class ConversationWatcher:
 
     def setup_daemon_logging(self):
         """Setup logging for daemon mode."""
+        # Debug the exact path being used
+        print(f"DAEMON LOGGING DEBUG: self.log_file = {self.log_file}")
+        print(f"DAEMON LOGGING DEBUG: absolute = {self.log_file.resolve()}")
         # Ensure log directory exists
         self.log_file.parent.mkdir(parents=True, exist_ok=True)
         # Create file handler for daemon logging
@@ -340,7 +351,8 @@ def run_watcher(
 ):
     """Run the file watcher in interactive mode."""
     data_dir = data_dir or os.environ.get("CLAUDE_SEARCH_DATA_DIR", "~/.claude-semantic-search/data")
-    data_dir = str(Path(data_dir).expanduser())  # Expand ~ to full path
+    # Always expand user path to handle ~ properly, even if already expanded
+    data_dir = str(Path(data_dir).expanduser())
     watcher = ConversationWatcher(data_dir, debounce_seconds, use_gpu)
 
     try:
@@ -358,7 +370,8 @@ def start_daemon(
 ):
     """Start the file watcher as a daemon."""
     data_dir = data_dir or os.environ.get("CLAUDE_SEARCH_DATA_DIR", "~/.claude-semantic-search/data")
-    data_dir = str(Path(data_dir).expanduser())  # Expand ~ to full path
+    # Always expand user path to handle ~ properly, even if already expanded  
+    data_dir = str(Path(data_dir).expanduser())
     watcher = ConversationWatcher(data_dir, debounce_seconds, use_gpu)
 
     # Fork process to run in background


### PR DESCRIPTION
## Summary
Fixes issue where the daemon fails to start due to improper handling of `~` in file paths.

## Problem
When running `claude-start`, the daemon would fail with:
```
❌ Failed to start daemon: [Errno 2] No such file or directory: '/Users/jrbaron/dev/pauloportella/dotfiles/~/.claude-semantic-search/data/watcher.log'
```

The issue was that `~` in the data directory path wasn't being expanded to the actual home directory.

## Solution
- Added `expanduser()` calls in all watcher functions to properly expand `~` to the full home directory path
- Fixed `ConversationWatcher.__init__` to expand `data_dir` path before creating PID and log files
- Fixed `run_watcher`, `start_daemon`, `stop_daemon`, `daemon_status` functions
- Fixed `mcp_server.py` `get_search_cli` function

## Changes
- `src/watcher.py`: Added `str(Path(data_dir).expanduser())` in 5 functions
- `src/mcp_server.py`: Added `str(Path(data_dir).expanduser())` in `get_search_cli`

## Test Plan
- [x] Run `uv run python -m pytest tests/test_watcher.py` - all tests pass
- [x] Test `claude-start` command - should now create log file at correct path
- [x] Verify daemon creates files at `/Users/[user]/.claude-semantic-search/data/`

## Resolves
The daemon now correctly creates files at `/Users/[user]/.claude-semantic-search/data/` instead of trying to create them at paths with literal `~` characters.